### PR TITLE
Highlighting of @option tags

### DIFF
--- a/features/stubs/some_class.rb
+++ b/features/stubs/some_class.rb
@@ -7,8 +7,10 @@ class SomeClass
 
   # Something else
   # @param library [String] the name of the library
-  # @param [String] version the version you have
-  def initialize(library, version)
+  # @param [String] version_number the version you have
+  # @param [Hash] options the options
+  # @option options [String] :an_option an option
+  def initialize(library, version_number, options = {})
     @version = version
   end
 

--- a/features/yard-mode.feature
+++ b/features/yard-mode.feature
@@ -28,14 +28,26 @@ Feature: yard-mode
     Then the face should be "yard-types-face"
     When I place the cursor after "@yieldparam version ["
     Then the face should be "yard-types-face"
+    When I place the cursor after "@option options ["
+    Then the face should be "yard-types-face"
 
   Scenario: YARD variable names are fontified when relevant
     When I place the cursor after "@return [Boolean, Array] "
     Then the face should be "font-lock-comment-face"
     When I place the cursor after "@param [String] "
     Then the face should be "yard-name-face"
+    When I place the cursor after "@param [String] version"
+    Then the face should be "yard-name-face"
+    When I place the cursor after "@param [String] version_"
+    Then the face should be "yard-name-face"
     When I place the cursor after "@yieldparam "
     Then the face should be "yard-name-face"
+    When I place the cursor after "@option "
+    Then the face should be "yard-name-face"
+
+  Scenario: YARD option names are fontified when relevant
+    When I place the cursor after "@option options [String] "
+    Then the face should be "yard-option-face"
 
   Scenario: ivars are not broken
     When I place the cursor before "@version"

--- a/yard-mode.el
+++ b/yard-mode.el
@@ -61,6 +61,12 @@ See http://rubydoc.info/docs/yard/file/docs/Tags.md#Tag_List"
   :type 'list
   :group 'yard)
 
+(defcustom yard-tags-with-options
+  '("option")
+  "YARD tags which require an option value."
+  :type 'list
+  :group 'yard)
+
 (defcustom yard-directives
   '("attribute" "endgroup" "group" "macro" "method"
     "parse" "scope" "visibility")
@@ -82,6 +88,9 @@ See http://rubydoc.info/docs/yard/file/docs/Tags.md#Directive_List"
 (defvar yard-tags-with-names-re
   (regexp-opt yard-tags-with-names))
 
+(defvar yard-tags-with-options-re
+  (regexp-opt yard-tags-with-options))
+
 (defface yard-tag-face
   '((t :inherit font-lock-doc-face))
   "Face for YARD tags."
@@ -102,6 +111,11 @@ See http://rubydoc.info/docs/yard/file/docs/Tags.md#Directive_List"
   "Face for YARD variable name; eg. 'name': @param [String] name"
   :group 'yard)
 
+(defface yard-option-face
+  '((t :inherit font-lock-constant-face))
+  "Face for YARD option name; eg. ':name': @option options [String] name"
+  :group 'yard)
+
 (defun yard-font-lock-keywords ()
   "Generate a list of keywords suitable for `font-lock-add-keywords'
 and `font-lock-remove-keywords'."
@@ -112,7 +126,11 @@ and `font-lock-remove-keywords'."
               " \\(\\(\\sw\\|\\s_\\)+\\)") 1 'yard-name-face t)
     (,(concat "# *@!?" yard-tags-with-names-re
               " \\[.+?\\] \\(\\(\\sw\\|\\s_\\)+\\)") 1 'yard-name-face t)
-    ))
+    (,(concat "# *@!?" yard-tags-with-options-re
+              " \\(\\(\\sw\\|\\s_\\)+\\)") 1 'yard-name-face t)
+    (,(concat "# *@!?" yard-tags-with-options-re
+              " \\(\\sw\\|\\s_\\)+ \\[.+?\\] \\(\\(:\\|\\sw\\|\\s_\\)+\\)") 2
+              'yard-option-face t)))
 
 (defun yard-in-comment-p ()
   "Returns whether point is currently inside of a comment."


### PR DESCRIPTION
Added regexps for highlighting "@option hash [Type] key"-style tags,
with the hash as a variable-name-face and key as a constant-face.

Signed-off-by: Erik Charlebois erik.charlebois@wishabi.com
