### PR TITLE
make eldoc polite

### DIFF
--- a/yard-mode.el
+++ b/yard-mode.el
@@ -1,4 +1,4 @@
-;;; yard-mode.el --- Minor mode for Ruby YARD comments
+;;; yard-mode.el --- Minor mode for Ruby YARD comments  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2017  Kyle Hargraves
 
@@ -191,17 +191,28 @@ The format is suitable for `font-lock-add-keywords' and `font-lock-remove-keywor
     (let ((tag (yard-tag-at-point)))
       (when tag (yard-tag-syntax tag)))))
 
+;; add-function arrived after emacs 24.?
+(declare-function add-function nil nil)
+(declare-function remove-function nil nil)
+
 (defun yard-turn-on ()
   "Turn on yard-mode."
   (font-lock-add-keywords nil (yard-font-lock-keywords))
   (when yard-use-eldoc
-    (set (make-local-variable 'eldoc-documentation-function) 'yard-eldoc-message)))
+    (if (fboundp 'add-function)
+        (add-function :before-until (local 'eldoc-documentation-function)
+                      #'yard-eldoc-message)
+      (set (make-local-variable 'eldoc-documentation-function)
+           #'yard-eldoc-message))))
 
 (defun yard-turn-off ()
   "Turn off yard-mode."
   (font-lock-remove-keywords nil (yard-font-lock-keywords))
   (when yard-use-eldoc
-    (set (make-local-variable 'eldoc-documentation-function) nil)))
+    (if (fboundp 'remove-function)
+        (remove-function (local 'eldoc-documentation-function)
+                         #'yard-eldoc-message)
+      (set (make-local-variable 'eldoc-documentation-function) nil))))
 
 ;;;###autoload
 (define-minor-mode yard-mode


### PR DESCRIPTION
Updates eldoc support to use advice (when defined - emacs 24+) instead
of clobbering.  This allows it to collaborate with robe's eldoc for example.