### PR TITLE
Fix cl deprecation warning

### DIFF
--- a/yard-mode.el
+++ b/yard-mode.el
@@ -28,7 +28,6 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
 (require 'regexp-opt)
 
 (defgroup yard nil


### PR DESCRIPTION
The `cl` package has been deprecated in Emacs 27 in favor of `cl-lib`, this PR removes the warning.